### PR TITLE
getByAttributes if more then one attribute.

### DIFF
--- a/src/AbstractRepository.php
+++ b/src/AbstractRepository.php
@@ -585,7 +585,7 @@ abstract class AbstractRepository
 	 */
 	public function getByAttributes(array $attributes)
 	{
-		if (count($attributes) > 1) {
+		if (empty($attributes)) {
 			throw new \InvalidArgumentException('Cannot getByAttributes with an empty array');
 		}
 


### PR DESCRIPTION
`getByAttributes` Failed when more then one attribute. I'm guessing with it not being called `getByAttribute` this should work as I intended with multiple attributes.
